### PR TITLE
Fix: missing __init__()

### DIFF
--- a/projects/challenge/smart_contracts/counter/contract.py
+++ b/projects/challenge/smart_contracts/counter/contract.py
@@ -7,8 +7,13 @@ class Counter(ARC4Contract):
     count: LocalState[UInt64]
     counters: GlobalState[UInt64]
 
+    def __init__(self) -> None:
+        self.count = LocalState(UInt64)
+        self.counters = GlobalState(UInt64(0))
+
     @arc4.baremethod(allow_actions=["OptIn"])
     def opt_in(self) -> None:
+        
         self.count[Txn.sender] = UInt64(0)
         self.counters.value += 1
 


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

States (Local & Global) initialization missing in __init__() method. 

**How did you fix the bug?**

Adding the __init__() method where we can initialize our states.
self.count & self.counters.

**Console Screenshot:**

![image](https://github.com/algorand-coding-challenges/python-challenge-2/assets/5107647/b9252d6c-b59b-45bb-aa44-acf2014e405b)
