### PR TITLE
Solution

### DIFF
--- a/projects/challenge/smart_contracts/counter/contract.py
+++ b/projects/challenge/smart_contracts/counter/contract.py
@@ -7,6 +7,10 @@ class Counter(ARC4Contract):
     count: LocalState[UInt64]
     counters: GlobalState[UInt64]
 
+    def __init__(self) -> None:
+        self.count = LocalState(UInt64)
+        self.counters = GlobalState(UInt64(0))
+
     @arc4.baremethod(allow_actions=["OptIn"])
     def opt_in(self) -> None:
         self.count[Txn.sender] = UInt64(0)


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

GlobalState and LocalState weren't initialized because (__Init__) was missing. 

**How did you fix the bug?**

Added the (__init__ ) to the Counter class, so it initialized the GlobalState and LocalState. 

**Console Screenshot:**

![image](https://github.com/algorand-coding-challenges/python-challenge-2/assets/63990513/3a3ea33d-a558-4278-84ff-ce3ea20595e8)

---
By the way, in the [Algokit CLI Documentation](https://github.com/algorandfoundation/algokit-cli/blob/main/docs/algokit.md) the [Deploy CLI command link](https://github.com/algorandfoundation/algokit-cli/blob/main/docs/features/deploy.md)  returns 404 not found. 
