### PR TITLE
Made the fix for the error. PR description will contain the explanation.

### DIFF
--- a/projects/challenge/smart_contracts/counter/contract.py
+++ b/projects/challenge/smart_contracts/counter/contract.py
@@ -4,8 +4,13 @@ from algopy import ARC4Contract, LocalState, GlobalState, UInt64, Txn, arc4, Glo
 
 class Counter(ARC4Contract):
 
-    count: LocalState[UInt64]
-    counters: GlobalState[UInt64]
+    def __init__(self) -> None:
+       self.count = LocalState(UInt64, key = "count", description = "Local of count")
+       self.counters = GlobalState(UInt64(0), key="counters", description="Global counters")
+
+    #count: LocalState[UInt64]
+    #counters: GlobalState[UInt64]
+
 
     @arc4.baremethod(allow_actions=["OptIn"])
     def opt_in(self) -> None:


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

The bug was that the count and counters local and global states were not initiated correctly. The variables lacked the key creation to be referred to in the sub methods.

**How did you fix the bug?**

I looked at the documentation, and defined the initial Counter variables, count (local) and counters (global). 

After some confusion with why I was getting a different error, I realized that in the case of counters, I needed to initiate it to 0, since it was immediately added to in the opt_in method, and therefore needed to be initiated with an initial value.

**Console Screenshot:**

![image](https://github.com/algorand-coding-challenges/python-challenge-2/assets/122029405/5d98549c-aef6-4527-9661-3dab55ed0073)
