### PR TITLE
[Fix] App state was declared as class variables

### DIFF
--- a/projects/challenge/smart_contracts/counter/contract.py
+++ b/projects/challenge/smart_contracts/counter/contract.py
@@ -3,9 +3,10 @@ from algopy import ARC4Contract, LocalState, GlobalState, UInt64, Txn, arc4, Glo
 
 
 class Counter(ARC4Contract):
-
-    count: LocalState[UInt64]
-    counters: GlobalState[UInt64]
+    def __init__(self) -> None:
+        self.count = LocalState(UInt64)
+        self.counters = GlobalState(UInt64)
+        self.counters.value = UInt64(0)
 
     @arc4.baremethod(allow_actions=["OptIn"])
     def opt_in(self) -> None:


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

Count and counters states were declared as class variables instead of instance one.

**How did you fix the bug?**

I added an __init__ method to declare those states as instances variables and I assigned a default value to counters so the '+=' operator doesn't fail.

**Console Screenshot:**

![image](https://github.com/algorand-coding-challenges/python-challenge-2/assets/162464577/4ff5d7e8-239f-4bb9-8784-1a8168209bad)
