### PR TITLE
Bug fixed: variables initialization

### DIFF
--- a/projects/challenge/smart_contracts/counter/contract.py
+++ b/projects/challenge/smart_contracts/counter/contract.py
@@ -4,8 +4,9 @@ from algopy import ARC4Contract, LocalState, GlobalState, UInt64, Txn, arc4, Glo
 
 class Counter(ARC4Contract):
 
-    count: LocalState[UInt64]
-    counters: GlobalState[UInt64]
+    def __init__(self) -> None:
+        self.count = LocalState(UInt64)
+        self.counters = GlobalState(UInt64(0))
 
     @arc4.baremethod(allow_actions=["OptIn"])
     def opt_in(self) -> None:


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

There was an error when initializing the variables, the init function had not been defined and some errors when declaring the variables.

**How did you fix the bug?**

I defined the init function
`def __init__(self) -> None:`
and fixed the variables declaration
```
        self.count = LocalState(UInt64)
        self.counters = GlobalState(UInt64(0))
```

**Console Screenshot:**

![image](https://github.com/algorand-coding-challenges/python-challenge-2/assets/14205644/9c730b26-d298-4331-974f-31fb2a3db9ef)
