### PR TITLE
Fix local and global counters

### DIFF
--- a/projects/challenge/smart_contracts/counter/contract.py
+++ b/projects/challenge/smart_contracts/counter/contract.py
@@ -3,14 +3,14 @@ from algopy import ARC4Contract, LocalState, GlobalState, UInt64, Txn, arc4, Glo
 
 
 class Counter(ARC4Contract):
-
-    count: LocalState[UInt64]
-    counters: GlobalState[UInt64]
+    def __init__(self) -> None:
+        self.counters = UInt64(0)
+        self.count = LocalState(UInt64)
 
     @arc4.baremethod(allow_actions=["OptIn"])
     def opt_in(self) -> None:
         self.count[Txn.sender] = UInt64(0)
-        self.counters.value += 1
+        self.counters += 1
 
     @arc4.abimethod()
     def increment(self) -> arc4.UInt64:


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

Incorrect declaration and initialization of local (`count`) and global (`counters`) state variables prevented building of the contract.
Additionally, the code incrementing `counters` value had an erroneous ".value" suffix in the variable name.

**How did you fix the bug?**

The bug was fixed by the proper initialization of the corresponding state variables in the `__init__()` function.

**Console Screenshot:**

![python_challenge_2](https://github.com/algorand-coding-challenges/python-challenge-2/assets/114208957/389ee064-d68d-447f-86e7-91339e0fac43)


